### PR TITLE
Switch title white

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -28,3 +28,8 @@ label[for="ipa"],label[for="nomeAmministrazione"],label[for="pec"] {
   max-height: 300px;
   overflow: auto;
 }
+
+/* Force text-white */
+.text-white {
+    color: white;
+}


### PR DESCRIPTION
The title's class was already `text-white`, however, the color in the css was grey (see #68). 
Forcing the class in the main.css file makes it white.
This is an ugly hack, do you foresee any better way to handle this @sebbalex? Thanks!