### PR TITLE
Add FAQ section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,9 @@
       <div class="row py-4 border-white border-top">
         <ul class="col list-inline small">
           <li class="list-inline-item px-1">
+            <a href="/faq" class="small-prints">Domande Frequenti</a>
+          </li>
+          <li class="list-inline-item px-1">
             <a href="//developers.italia.it/it/privacy-policy/" class="small-prints">Privacy Policy</a>
           </li>
           <li class="list-inline-item px-1">

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const init = async () => {
   const registeredHandler = require('./src/registered');
   const repoHandler = require('./src/repo-list');
   const homeHandler = require('./src/home');
+  const faqHandler = require('./src/faq');
 
   const appConfig = JSON.parse(process.argv.includes('dev') ?
     fs.readFileSync('config-dev.json').toString('utf8') :
@@ -93,6 +94,10 @@ const init = async () => {
     path: '/',
     handler: homeHandler
   }, {
+    method: 'GET',
+    path: '/faq',
+    handler: faqHandler
+  },{
     method: 'GET',
     path: '/{param*}',
     handler: {

--- a/src/faq.js
+++ b/src/faq.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function (request, h) {
+  return h.view('faq', null, { layout: 'index' });
+};

--- a/src/tpl/faq.html
+++ b/src/tpl/faq.html
@@ -1,0 +1,252 @@
+<main id="content">
+    <div class="d-flex align-items-center justify-content-center main-content mt-5">
+        <div class="container">
+            <div class="row">
+                <div class="my-5 col-md-8">
+
+                    <h2>Domande Frequenti (F.A.Q.)</h2>
+
+                    <div id="collapseDiv1" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading1">
+                        <button data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1">
+                          1. A cosa serve la procedura di onboarding?
+                        </button>
+                      </div>
+                      <div id="collapse1" class="collapse" role="tabpanel" aria-labelledby="heading1">
+                        <div class="collapse-body">
+                          La procedura di onboarding consente alle amministrazioni pubbliche di dichiarare lo strumento di code hosting prescelto ai sensi delle Linee guida sull’acquisizione e il riuso di software, all’interno del quale le amministrazioni pubblicheranno il software di cui sono titolari. A seguito di questa procedura, le soluzioni software presenti nei repository (purché corredate da file descrittivi denominati <a href="https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/index.html">publiccode.yml</a>) saranno automaticamente indicizzate nel <a href="https://developers.italia.it/it/software">catalogo del software di Developers Italia</a>. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv2" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading2">
+                        <button data-toggle="collapse" data-target="#collapse2" aria-expanded="false" aria-controls="collapse2">
+                          2. Cos’è uno strumento di code hosting?
+                        </button>
+                      </div>
+                      <div id="collapse2" class="collapse" role="tabpanel" aria-labelledby="heading2">
+                        <div class="collapse-body">
+                          Uno strumento di code hosting è una piattaforma che consente la pubblicazione di codice sorgente, organizzato in più repository. Gli strumenti di code hosting offrono spesso anche funzionalità legate all’evoluzione di un software quali sistemi di ticketing, processi per la contribuzione di codice da parte di terzi, area per il download dei rilasci, ecc. Esistono diverse piattaforme che espletano tali funzionalità e le Linee guida per l’acquisizione e il riuso di software per la Pubblica Amministrazione elencano una serie di di requisiti da soddisfare perché la piattaforma possa essere considerata adeguata. Per una descrizione di tali requisiti si vedano le <a href="https://docs.italia.it/italia/developers-italia/lg-acquisizione-e-riuso-software-per-pa-docs/it/stabile/attachments/allegato-a-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa.html">linee guida</a>. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv3" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading3">
+                        <button data-toggle="collapse" data-target="#collapse3" aria-expanded="false" aria-controls="collapse3">
+                          3. Come funziona il processo di onboarding?
+                        </button>
+                      </div>
+                      <div id="collapse3" class="collapse" role="tabpanel" aria-labelledby="heading3">
+                        <div class="collapse-body">
+                          Il processo inizia con la compilazione, da parte dell’ente, di un form con delle informazioni relative al referente (la persona che sta effettuando la registrazione), all’amministrazione e alla piattaforma di code hosting. Dopo un controllo (che può richiedere fino a 7 giorni lavorativi), l’Agenzia per l’Italia Digitale inviauna comunicazione via PEC all’indirizzo dell’ente comunicato attraverso il precedente form. Tale PEC contiene un link di conferma: aprendo tale link l’ente confermerà infatti la richiesta di onboarding e la procedurà potrà ritenersi conclusa. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv4" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading4">
+                        <button data-toggle="collapse" data-target="#collapse4" aria-expanded="false" aria-controls="collapse4">
+                          4. Non ho ricevuto la PEC, come devo fare?
+                        </button>
+                      </div>
+                      <div id="collapse4" class="collapse" role="tabpanel" aria-labelledby="heading4">
+                        <div class="collapse-body">
+                          La procedura di verifica dei dati inseriti avviene in modalità asincrona e può impiegare diversi giorni. Nel caso in cui il messaggio tardi più di 7 giorni lavorativi ad arrivare è possibile chiederne riscontro nei canali di comunicazione di Developers Italia (si veda la sezione <a href="https://developers.italia.it/it/contatti">contatti</a>). 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv5" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading5">
+                        <button data-toggle="collapse" data-target="#collapse5" aria-expanded="false" aria-controls="collapse5">
+                          5. Chi è il referente da indicare nel form?
+                        </button>
+                      </div>
+                      <div id="collapse5" class="collapse" role="tabpanel" aria-labelledby="heading5">
+                        <div class="collapse-body">
+                          Il referente è la persona che effettua la richiesta di onboarding. Non è necessario che tale persona sia il rappresentante legale dell’ente, ma è ovviamente necessario che abbia i permessi o le deleghe interne per poter effettuare la richiesta. Tale nominativo sarà citato nella PEC indirizzata all'Amministrazione richiedente in modo da facilitare lo smistamento del messaggio all'interno dell'Amministrazione stessa. E’ necessario inserire nome e cognome del referente unitamente ad un numero di telefono che potrà essere utilizzato per richiedere eventuali chiarimenti. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv6" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading6">
+                        <button data-toggle="collapse" data-target="#collapse6" aria-expanded="false" aria-controls="collapse6">
+                          6. Perché non posso scegliere l’indirizzo PEC di destinazione o indicare un altro indirizzo e-mail?
+                        </button>
+                      </div>
+                      <div id="collapse6" class="collapse" role="tabpanel" aria-labelledby="heading6">
+                        <div class="collapse-body">
+                          È possibile scegliere solo tra gli indirizzi PEC riportati in IndicePA per ciascun ente.
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv7" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading7">
+                        <button data-toggle="collapse" data-target="#collapse7" aria-expanded="false" aria-controls="collapse7">
+                          7. I dati riportati automaticamente non sono corretti. Come posso cambiarli?
+                        </button>
+                      </div>
+                      <div id="collapse7" class="collapse" role="tabpanel" aria-labelledby="heading7">
+                        <div class="collapse-body">
+                          Se i dati riportati nei campi compilati automaticamente non dovessero essere corretti o non aggiornati è necessario aggiornarli presso IndicePA. Per farlo si veda la <a href="https://www.indicepa.gov.it/documentale/n-domande.php#A3">sezione domande di IndicePA</a>. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv8" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading8">
+                        <button data-toggle="collapse" data-target="#collapse8" aria-expanded="false" aria-controls="collapse8">
+                          8. Se sbaglio, come posso fare a correggere la richiesta?
+                        </button>
+                      </div>
+                      <div id="collapse8" class="collapse" role="tabpanel" aria-labelledby="heading8">
+                        <div class="collapse-body">
+                          In caso di errore è possibile effettuare una seconda richiesta contenente i dettagli corretti. L’ultima richiesta verrà considerata quella corretta e processata. Le richieste precedenti verranno scartate. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv9" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading9">
+                        <button data-toggle="collapse" data-target="#collapse9" aria-expanded="false" aria-controls="collapse9">
+                          9. Posso aggiungere un’altro spazio di code-hosting a quello già presente per la mia PA?
+                        </button>
+                      </div>
+                      <div id="collapse9" class="collapse" role="tabpanel" aria-labelledby="heading9">
+                        <div class="collapse-body">
+                          Si, nel caso in cui l’ente abbia il controllo di diverse organizzazioni su diverse piattaforme di code hosting è possibile effettuare molteplici richieste di onboarding, una per ogni piattaforma controllata. Si suggerisce, compatibilmente con i vincoli organizzativi dell’ente, di utilizzare un solo spazio di code hosting in modo da consolidare i repository in un solo luogo. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv10" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading10">
+                        <button data-toggle="collapse" data-target="#collapse10" aria-expanded="false" aria-controls="collapse10">
+                          10. Come posso essere sicuro che il processo sia andato a buon fine?
+                        </button>
+                      </div>
+                      <div id="collapse10" class="collapse" role="tabpanel" aria-labelledby="heading10">
+                        <div class="collapse-body">
+                          Il processo di onboarding si conclude dopo la seconda fase, ovvero quando verrà visualizzata la pagina di buona riuscita dell’operazione. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv11" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading11">
+                        <button data-toggle="collapse" data-target="#collapse11" aria-expanded="false" aria-controls="collapse11">
+                          11. Non vedo il software nel catalogo, perché?
+                        </button>
+                      </div>
+                      <div id="collapse11" class="collapse" role="tabpanel" aria-labelledby="heading11">
+                        <div class="collapse-body">
+                          Lo svolgimento di una corretta procedura di onboarding non garantisce che il software inserito all’interno di uno dei repository contenuti nell’organizzazione indicata sia automaticamente inserito nel catalogo. 
+                          Tra le cause è possibile citare:
+                          <ul>                          
+                            <li>Processo di onboarding incompleto.</li>
+                            <li>Processo di onboarding completato da meno di 24 ore.</li>
+                            <li>Il crawler effettua le sue operazioni di routine di notte. E’ consigliabile attendere la giornata seguente al termine del processo per visualizzare correttamente il software nel catalogo.</li>
+                            <li>Mancanza del file “publiccode.yml” all’interno di uno dei repository contenuti nello strumento di code hosting.</li>
+                            <li>Errori nel file “publiccode.yml”.</li>
+                            <li>Se il file “publiccode.yml” inserito all’interno del repository in questione dovesse presentare degli errori, il crawler scarterà la sua indicizzazione che avverrà correttamente solo quando tali errori saranno corretti.</li>
+                            <li>Violazione delle policy del catalogo.</li>
+                          </ul>
+                          Per maggiori informazioni sulle policy si vedano le <a href="https://docs.italia.it/italia/developers-italia/policy-inserimento-catalogo-docs/it/stabile/">policy</a>.
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv12" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading12">
+                        <button data-toggle="collapse" data-target="#collapse12" aria-expanded="false" aria-controls="collapse12">
+                          12. Posso eliminare una piattaforma di code hosting dal catalogo?
+                        </button>
+                      </div>
+                      <div id="collapse12" class="collapse" role="tabpanel" aria-labelledby="heading12">
+                        <div class="collapse-body">
+                          Al momento non è possibile effettuare la rimozione automatica. Per ulteriori informazioni circa la rimozione di una organizzazione del catalogo è possibile chiedere informazioni nei canali di <a href="https://developers.italia.it/it/contatti">comunicazione di Developers Italia</a>.
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv13" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading13">
+                        <button data-toggle="collapse" data-target="#collapse13" aria-expanded="false" aria-controls="collapse13">
+                          13. E’ cambiato il referente di progetto, come posso fare?
+                        </button>
+                      </div>
+                      <div id="collapse13" class="collapse" role="tabpanel" aria-labelledby="heading13">
+                        <div class="collapse-body">
+                          Il ruolo del referente è necessario esclusivamente in fase di inserimento iniziale. Pertanto non è necessario variare il nominativo a posteriori. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv14" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading14">
+                        <button data-toggle="collapse" data-target="#collapse14" aria-expanded="false" aria-controls="collapse14">
+                          14. Quante volte verrò contattato all’indirizzo PEC segnalato?
+                        </button>
+                      </div>
+                      <div id="collapse14" class="collapse" role="tabpanel" aria-labelledby="heading14">
+                        <div class="collapse-body">
+                          Verrà inviata una sola comunicazione all’indirizzo PEC segnalato. Tale comunicazione avrà come mittente un indirizzo PEC con dominio @agid.gov.it. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv15" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading15">
+                        <button data-toggle="collapse" data-target="#collapse15" aria-expanded="false" aria-controls="collapse15">
+                          15. Per ulteriori domande chi posso contattare?
+                        </button>
+                      </div>
+                      <div id="collapse15" class="collapse" role="tabpanel" aria-labelledby="heading15">
+                        <div class="collapse-body">
+                          Per ricevere ulteriore supporto circa le corrette modalità di onboarding è possibile utilizzare gli strumenti di comunicazione messi a disposizione da Developers Italia quali il Forum, lo Slack o gli indirizzi mail di contatto. Per ulteriori informazioni è possibile consultare la sezione <a href="https://developers.italia.it/it/contatti">contatti di Developers Italia</a>. 
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv16" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading16">
+                        <button data-toggle="collapse" data-target="#collapse16" aria-expanded="false" aria-controls="collapse16">
+                          16. La PEC segnalata non è corretta. 
+                        </button>
+                      </div>
+                      <div id="collapse16" class="collapse" role="tabpanel" aria-labelledby="heading16">
+                        <div class="collapse-body">
+                          Si veda <a href="#heading5">5</a>.  
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv17" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading17">
+                        <button data-toggle="collapse" data-target="#collapse17" aria-expanded="false" aria-controls="collapse17">
+                          17. Il nome della mia amministrazione non appare. 
+                        </button>
+                      </div>
+                      <div id="collapse17" class="collapse" role="tabpanel" aria-labelledby="heading17">
+                        <div class="collapse-body">
+                          Si veda <a href="#heading5">5</a>.  
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv18" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading18">
+                        <button data-toggle="collapse" data-target="#collapse18" aria-expanded="false" aria-controls="collapse18">
+                          18. E' possibile utilizzare uno strumento di code hosting installato on-premises?
+                        </button>
+                      </div>
+                      <div id="collapse18" class="collapse" role="tabpanel" aria-labelledby="heading18">
+                        <div class="collapse-body">
+                          Si, è possibile inserire la URL del proprio repository pubblico. Quest’ultimo, però, deve essere compatibile con le indicazioni presenti nelle <a href="https://docs.italia.it/italia/developers-italia/lg-acquisizione-e-riuso-software-per-pa-docs/it/stabile/attachments/allegato-a-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa.html#individuazione-dello-strumento-di-code-hosting">linee guida.</a>
+                        </div>
+                      </div>
+                    </div>
+                    <div id="collapseDiv19" class="collapse-div" role="tablist">
+                      <div class="collapse-header" id="heading19">
+                        <button data-toggle="collapse" data-target="#collapse19" aria-expanded="false" aria-controls="collapse19">
+                          19. Non sono una Pubblica Amministrazione ma voglio pubblicare il mio software open source nel catalogo: devo fare lo stesso la procedura di onboarding?
+                        </button>
+                      </div>
+                      <div id="collapse19" class="collapse" role="tabpanel" aria-labelledby="heading19">
+                        <div class="collapse-body">
+                          No, la procedura di onboarding qui descritta è riservata alla Pubblica Amministrazione. Per includere software di terze parti si vedano le istruzioni presenti nel sito <a href="https://developers.italia.it/it/riuso/pubblicazione">Developers Italia</a>.
+                        </div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/src/tpl/main-content.html
+++ b/src/tpl/main-content.html
@@ -19,6 +19,7 @@
               La compilazione di questo form genererà una PEC contenente un link che l'Ente dovrà seguire per confermare
               l'iscrizione con un semplice click: è pertanto una semplice procedura di verifica per accertare la
               titolarità degli account usati per la pubblicazione del software.
+              Per ulteriori informazioni consultare la sezione <a href="/faq">domande frequenti</a>.
             </h5>
             <br />
             <div class="form-group">


### PR DESCRIPTION
This PR:
* adds a FAQ page mapped to `/faq`
* adds link in homepage
* adds link in footer

Fixing #94 

@sebbalex I am not convinced on numbering the questions manually... any ideas about it? 
Furthermore, using the heading id to create and internal hook is broken, meaning that the header is overlapping the actual text (pic following). 