### PR TITLE
fix: check the iPA against the correct PEC

### DIFF
--- a/src/email-sent.js
+++ b/src/email-sent.js
@@ -26,7 +26,7 @@ module.exports = async function (request, h) {
   let validationResultUrl = validator.url(url);
   let validationResultPhone = validator.phone(refTel);
   let validationCheckDups = validator.checkDups(ipa, url);
-  const validationIpaMatchesPec = await validator.ipaMatchesPec(ipa, pec);
+  const validationIpaMatchesPec = await validator.ipaMatchesPec(ipa, originalPec);
 
   if (validationResultUrl != VALIDATION_OK) {
     let data = {errorMsg: getErrorMessage(validationResultUrl)};


### PR DESCRIPTION
The iPA check must be done against the PA's PEC, not the overridden
one which can be different from the original.