### PR TITLE
Feat(copy): copy fixes in homepage and headers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Onboarding. Registra in Developers Italia il tuo strumento di code hosting.">
+  <meta name="description" content="Onboarding - Registra in Developers Italia il tuo strumento di code hosting">
   <meta name="author" content="Dipartimento per la Trasformazione Digitale">
   <meta name="robots" content="noindex">
 
@@ -33,15 +33,15 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@https://twitter.com/teamdigitaleIT">
+  <meta name="twitter:site" content="@developersITA">
   <meta name="twitter:creator" content="Dipartimento per la Trasformazione Digitale">
-  <meta name="twitter:title" content="Onboarding portal for Developers Italia">
+  <meta name="twitter:title" content="Portale di onboarding per Developers Italia">
   <meta name="twitter:description" content="Onboarding è il portale tramite cui le pubbliche amministrazioni possono registrare i propri prepository open source e permettere che vengano indicizzati tramite il relativo file pubbliccode">
   <!-- <meta name="twitter:image" content="/assets/img/favicons/social-card.png"> -->
 
   <!-- Facebook -->
   <meta property="og:url" content="/">
-  <meta property="og:title" content="Onboarding portal for Developers Italia">
+  <meta property="og:title" content="Portale di onboarding per Developers Italia">
   <meta property="og:description" content="Onboarding è il portale tramite cui le pubbliche amministrazioni possono registrare i propri prepository open source e permettere che vengano indicizzati tramite il relativo file pubbliccode">
   <meta property="og:type" content="website">
   <!-- <meta property="og:image" content="/assets/img/favicons/social-card.png"> -->
@@ -49,8 +49,6 @@
   <!-- <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630"> -->
-
-  <!-- TODO GA -->
 
 </head>
 


### PR DESCRIPTION
This PR introduces some changes in the homepage copy, in particular:

* Changed some descriptions in the fields and paid more attention to the organization's URL
* Minimal changes in the main text body (it will generate a PEC -> send a PEC) and made bold and divided

Also fixed some text in the header about social (twitter desc, etc)

**Preview:**

![image](https://user-images.githubusercontent.com/5399264/186372554-fb6ec9d4-f4be-47cd-86f1-e9f2ae59af5b.png)
