### PR TITLE
fix: use just the iPA code for the alternativeId

### DIFF
--- a/src/register-fast-onboarding.js
+++ b/src/register-fast-onboarding.js
@@ -104,7 +104,7 @@ async function createPublisher(apiURL, pasetoApiToken, pec, amministrazione, ipa
     codeHosting: [{
       url: url
     }],
-    alternativeId: `${ipa}-${pec}`,
+    alternativeId: ipa,
   };
 
   const res = await fetch(`${apiURL}/publishers`, {

--- a/src/registered.js
+++ b/src/registered.js
@@ -106,7 +106,7 @@ async function createPublisher(apiURL, pasetoApiToken, pec, amministrazione, ipa
     codeHosting: [{
       url: url
     }],
-    alternativeId: `${ipa}-${pec}`,
+    alternativeId: ipa,
   };
 
   const res = await fetch(`${apiURL}/publishers`, {


### PR DESCRIPTION
The alternativeId is checked against the it.riuso.codiceIPA in publiccode.yml and the two must match for the software to get into the catalog.

Initially the `${ipa}-{$pec}` combo was thought to allow different units of a bigger PA to have their own publisher and onboard in a more granular way, but the data modeling on the IndicePA is kinda patchy and confusing. So let's say: one iPA code == one publisher.

We support the onboarding to an existing PA though, adding the code hosting to the ones already there,  which make sense and is probably better? question mark?