### PR TITLE
fix: query `/v1/publishers/${ipa}`

### DIFF
--- a/src/register-fast-onboarding.js
+++ b/src/register-fast-onboarding.js
@@ -60,7 +60,7 @@ module.exports = async function(request, h) {
   const apiURL = config.apiURL.replace(/\/$/, '');
 
   try {
-    const getPublisherResp = await fetch(`${apiURL}/publishers/${ipa}-${pec}`, {
+    const getPublisherResp = await fetch(`${apiURL}/publishers/${ipa}`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.pasetoApiToken}` },
     });

--- a/src/registered.js
+++ b/src/registered.js
@@ -53,7 +53,7 @@ module.exports = async function(request, h) {
   const apiURL = config.apiURL.replace(/\/$/, '');
 
   try {
-    const getPublisherResp = await fetch(`${apiURL}/publishers/${ipa}-${pec}`, {
+    const getPublisherResp = await fetch(`${apiURL}/publishers/${ipa}`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.pasetoApiToken}` },
     });


### PR DESCRIPTION
Querying `/v1/publishers/${ipa}-${pec}` yields 404.